### PR TITLE
Disable cache for live reload

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,7 @@ var slmOutput = "./dist/html";
 
 gulp.task('slm', function(){
   return gulp.src(slmFiles)
-    .pipe(slm())
+    .pipe(slm({useCache: false}))
     .pipe(gulp.dest(slmOutput));
 });
 


### PR DESCRIPTION
Hi. By default Slm does cache everything it can. You can disable caching for live reload.

Thank you for issue.